### PR TITLE
Llama pro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ nbs/profile_snapshots
 nbs/tmp-*
 data/
 sbatch_outputs/
+
+# python ignores
+__pycache__/
+*.pyc
+*.pyo
+*.pyd

--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ LoRA fine-tuning using a custom LoRA module.
 + --train_type hqq_lora \
 ```
 
+### `--train_type bnb_dora`
+
+4-bit quantized DoRA fine-tuning using bitsanbytes Linear4bit layer with NF4 quantization and a custom DoRA module.
+
+```diff
+- --train_type full \
++ --train_type bnb_dora \
+```
+
+### `--train_type hqq_dora`
+
+4-bit quantized DoRA fine-tuning using HQQ library and a custom DoRA module.
+
+```diff
+- --train_type full \
++ --train_type hqq_dora \
+```
+
 ## Low Memory Loading
 
 During quantized LoRA training we use a custom quantization and loading code to avoid loading the entire model into GPU memory before sharding it across GPUs. This is the default behavior of our training script when any of the following training options `"qlora", "custom_qlora", "hqq_lora"` is used. Other training options are already optimized for low memory loading to their best extent.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,44 @@ LoRA fine-tuning using a custom LoRA module.
 + --train_type hqq_dora \
 ```
 
+### `--train_type bnb_llama_pro`
+
+4-bit quantized Llama-Pro fine-tuning using bitsanbytes Linear4bit layer with NF4 quantization.
+
+To create llama-pro weights, run the following command:
+
+```bash
+python scripts/block_expansion.py \
+--model_name meta-llama/Llama-2-7b-hf \
+--output_dir /path/to/llama_pro_weights_directory \
+--expansion_rate 0.1
+```
+
+```diff
+- --train_type full \
++ --train_type bnb_llama_pro \
++ --llama_pro_path /path/to/llama_pro_weights_directory \
+```
+
+### `--train_type hqq_llama_pro`
+
+4-bit quantized Llama-Pro fine-tuning using HQQ library.
+
+To create llama-pro weights, run the following command:
+
+```bash
+python scripts/block_expansion.py \
+--model_name meta-llama/Llama-2-7b-hf \
+--output_dir /path/to/llama_pro_weights_directory \
+--expansion_rate 0.1
+```
+
+```diff
+- --train_type full \
++ --train_type hqq_llama_pro \
++ --llama_pro_path /path/to/llama_pro_weights_directory \
+```
+
 ## Low Memory Loading
 
 During quantized LoRA training we use a custom quantization and loading code to avoid loading the entire model into GPU memory before sharding it across GPUs. This is the default behavior of our training script when any of the following training options `"qlora", "custom_qlora", "hqq_lora"` is used. Other training options are already optimized for low memory loading to their best extent.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following steps should work (tested on Cuda 11.7, 11.8 and 12.1):
 - Install bitsandbytes `pip install bitsandbytes>=0.43.0`
 - Run `huggingface-cli login` (to access Llama 2)
 - Optional Libraries:
-  - HQQ quantization: follow the HQQ installation [instructions](https://github.com/mobiusml/hqq?tab=readme-ov-file#installation). Our training script uses `HQQBackend.ATEN_BACKPROP`, so also make sure to build the custom kernels `cd hqq/kernels && python setup_cuda.py install`.
+  - HQQ quantization: follow the HQQ installation [instructions](https://github.com/mobiusml/hqq?tab=readme-ov-file#installation). Our training script uses `HQQBackend.ATEN_BACKPROP`, so also make sure to build the custom kernels `cd hqq/kernels && python setup_cuda.py install`. Pin commit to `72b2b641aadc44a7ded6b243915f90df3b3be385` for FSDP compatibility, until `to_empty()` method is fixed. 
   - Weights and Biases logging: `pip install wandb`
 - [Pytorch >= 2.2](https://pytorch.org/blog/pytorch2-2/) is recommended to make use of the native flash-attention 2 kernel.
 

--- a/scripts/block_expansion.py
+++ b/scripts/block_expansion.py
@@ -1,0 +1,60 @@
+
+import argparse
+from transformers import AutoConfig
+import torch
+from transformers.utils import hub, SAFE_WEIGHTS_NAME, SAFE_WEIGHTS_INDEX_NAME
+import safetensors
+from safetensors.torch import save_file
+import os 
+from pathlib import Path
+
+def main():
+    # Set up the argument parser
+    parser = argparse.ArgumentParser(description="Receive deepen model's args")
+    parser.add_argument("--model_name", default='meta-llama/Llama-2-7b-hf', type=str, help="original model path")
+    parser.add_argument("--output_dir", default=None, type=str, help="deepened model ckpt save path")
+    parser.add_argument("--expansion_rate", default=0.1, type=float, help="add new trainable % of layers")
+
+    # Parse the arguments
+    args = parser.parse_args()
+        
+    idx = hub.cached_file(args.model_name, SAFE_WEIGHTS_INDEX_NAME)
+    files, _ = hub.get_checkpoint_shard_files(args.model_name, idx)
+    
+    cfg = AutoConfig.from_pretrained(args.model_name)
+    num_original_layers = cfg.num_hidden_layers
+    new_layers = num_original_layers + int(num_original_layers * args.expansion_rate)
+    
+    split = int(num_original_layers / (new_layers - num_original_layers))
+    
+    if args.output_dir is None:
+        output_dir = Path(os.environ['HOME'])/'models'/(args.model_name + f'_blk_exp-{num_original_layers}-{new_layers}')
+    else:
+        output_dir = Path(args.output_dir)/(args.model_name + f'_blk_exp-{num_original_layers}-{new_layers}')
+    os.makedirs(output_dir, exist_ok=True)
+    
+    for filename in files:
+        weights = safetensors.torch.load_file(filename)
+        expanded_weights = {}
+        for k,v in iter(weights.items()):
+            if 'layers' in k:
+                layer_no = int(k.split('layers.')[1].split('.')[0])
+                # shift existing layers
+                new_layer_no = layer_no + layer_no // split
+                new_k = k.replace(f'layers.{layer_no}', f'layers.{new_layer_no}')
+                expanded_weights[new_k] = v
+                # add new layers
+                if (layer_no+1) % split == 0:
+                    new_layer_no += 1
+                    new_k = k.replace(f'layers.{layer_no}', f'layers.{new_layer_no}')
+                    if 'down_proj' in k or 'o_proj' in k:
+                        expanded_weights[new_k] = torch.zeros_like(v)     
+                    else:
+                        expanded_weights[new_k] = v.clone()
+            else:
+                expanded_weights[k] = v
+        save_file(expanded_weights, output_dir/Path(filename).name)
+    
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dora.py
+++ b/scripts/dora.py
@@ -1,0 +1,114 @@
+import torch
+import torch.nn as nn
+import bitsandbytes as bnb
+
+# Wrapping policy requires modules, base_layer has no grad params, lora_A, lora_B, dora_scale have grad params.
+class DORALayer(nn.Module):
+    "Same as LORA but also returnes weight norm. This will be wrapped as a single FSDP unit"
+    def __init__(self, in_features, out_features, lora_rank, device, dtype, *args, **kwargs):
+        super().__init__()
+        # Init LoRA layers.
+        std_dev = 1 / torch.sqrt(torch.tensor(lora_rank).float())
+        lora_A_param = nn.Parameter(torch.randn(lora_rank, in_features).to(device=device, dtype=dtype)*std_dev)
+        self.lora_A = nn.Linear(in_features, lora_rank, bias=False, device=device, dtype=dtype)
+        setattr(self.lora_A, "weight", lora_A_param)
+        
+        self.lora_B = nn.Linear(lora_rank, out_features, bias=False, device=device, dtype=dtype)
+        self.lora_B.weight.data.zero_()
+    
+    def forward(self, x, frozen_weight):
+        output = self.lora_B(self.lora_A(x))
+        # print("lora A shape:", self.lora_A.weight.shape)
+        # print("lora B shape:", self.lora_B.weight.shape)
+        # DoRA Section 4.3. Detach column norm to avoid backprop through it.
+        column_norm = (frozen_weight + self.lora_B.weight @ self.lora_A.weight).norm(p=2, dim=1).detach()
+        # print("column norm shape:", column_norm.shape, column_norm.shape)
+        return output, column_norm
+    
+class MagnitudeLayer(nn.Module):
+    "FSDP doesn't work with nn.ParameterDict hence this module: https://github.com/pytorch/pytorch/issues/79605"
+    def __init__(self, vector_data, device, dtype):
+        super().__init__()
+        self.magnitude = nn.Parameter(vector_data.to(device=device, dtype=dtype))
+        
+    def forward(self, x):
+        return x * self.magnitude.view(1,1,-1)
+    
+class HQQDORA(nn.Module):
+    def __init__(self, base_layer, lora_rank, *args, **kwargs):
+        super().__init__()
+        self.base_layer = base_layer
+        dtype = getattr(base_layer, "compute_dtype", next(base_layer.parameters()).dtype)
+        device = next(base_layer.parameters()).device
+        
+        # Init trainable magnitude parameter.
+        self.magnitude_layer = MagnitudeLayer(self.base_layer.dora_scale.clone().to(dtype=dtype), device, dtype)
+        self.base_layer.dora_scale = None
+        torch.cuda.empty_cache()
+        
+        # Init DORA layers.
+        self.dora_layer = DORALayer(base_layer.in_features, base_layer.out_features, lora_rank, device, dtype, *args, **kwargs)
+
+    def forward(self, x, *args, **kwargs):
+        result = self.base_layer(x, *args, **kwargs)
+        # As per Tim Dettmers, for 4bit, we need to defensively clone here.
+        # The reason is that in some cases, an error can occur that backprop
+        # does not work on a manipulated view. This issue may be solved with
+        # newer PyTorch versions but this would need extensive testing to be
+        # sure.
+        result = result.clone()
+
+        requires_conversion = not torch.is_autocast_enabled()
+        if requires_conversion:
+            expected_dtype = result.dtype
+            x = x.to(self.dora_layer.lora_A.weight.dtype)
+
+        # m * (W + AB / ||W + AB||) @ X == m * ((W @ X + AB @ X) / ||W + AB||)
+        output, column_norm = self.dora_layer(x, self.base_layer.dequantize_aten())
+        if requires_conversion:
+            output = output.to(expected_dtype)
+        
+        result += output        
+        result = result / column_norm.view(1,1,-1) #unit vector result.
+        result = self.magnitude_layer(result) #rescaled result.
+        return result
+    
+class BNBDORA(nn.Module):
+    def __init__(self, base_layer, lora_rank, *args, **kwargs):
+        super().__init__()
+        self.base_layer = base_layer
+        dtype = getattr(base_layer, "compute_dtype", next(base_layer.parameters()).dtype)
+        device = next(base_layer.parameters()).device
+        
+        # Init trainable magnitude parameter.
+        self.magnitude_layer = MagnitudeLayer(self.base_layer.dora_scale.clone().to(dtype=dtype), device, dtype)
+        self.base_layer.dora_scale = None
+        torch.cuda.empty_cache()
+        
+        # Init DORA layers.
+        self.dora_layer = DORALayer(base_layer.in_features, base_layer.out_features, lora_rank, device, dtype, *args, **kwargs)
+
+    def forward(self, x, *args, **kwargs):
+        result = self.base_layer(x, *args, **kwargs)
+        # As per Tim Dettmers, for 4bit, we need to defensively clone here.
+        # The reason is that in some cases, an error can occur that backprop
+        # does not work on a manipulated view. This issue may be solved with
+        # newer PyTorch versions but this would need extensive testing to be
+        # sure.
+        result = result.clone()
+
+        requires_conversion = not torch.is_autocast_enabled()
+        if requires_conversion:
+            expected_dtype = result.dtype
+            x = x.to(self.dora_layer.lora_A.weight.dtype)
+
+        # m * (W + AB / ||W + AB||) @ X == m * ((W @ X + AB @ X) / ||W + AB||)
+        output, column_norm = self.dora_layer(x, bnb.functional.dequantize_4bit(self.base_layer.weight.data, 
+                                                                                self.base_layer.weight.quant_state))
+        if requires_conversion:
+            output = output.to(expected_dtype)
+        
+        result += output        
+        result = result / column_norm.view(1,1,-1) #unit vector result.
+        result = self.magnitude_layer(result) #rescaled result.
+        return result

--- a/scripts/lora.py
+++ b/scripts/lora.py
@@ -1,0 +1,42 @@
+import torch
+import torch.nn as nn
+
+class LORA(nn.Module):
+    def __init__(self, base_layer, lora_rank, lora_alpha, lora_dropout):
+        super().__init__()
+        self.base_layer = base_layer
+        dtype = getattr(base_layer, "compute_dtype", next(base_layer.parameters()).dtype)
+        device = next(base_layer.parameters()).device
+        lora_A = nn.Linear(base_layer.in_features, lora_rank, bias=False, device=device, dtype=dtype)
+        lora_B = nn.Linear(lora_rank, base_layer.out_features, bias=False, device=device, dtype=dtype)
+        lora_B.weight.data.zero_()
+
+        self.lora_AB = nn.Sequential(lora_A, lora_B)
+
+        self.lora_alpha = lora_alpha
+        self.lora_dropout = nn.Dropout(lora_dropout)
+        self.scaling = self.lora_alpha / lora_rank
+
+    def forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+
+        result = self.base_layer(x, *args, **kwargs)
+        # As per Tim Dettmers, for 4bit, we need to defensively clone here.
+        # The reason is that in some cases, an error can occur that backprop
+        # does not work on a manipulated view. This issue may be solved with
+        # newer PyTorch versions but this would need extensive testing to be
+        # sure.
+        result = result.clone()
+
+        requires_conversion = not torch.is_autocast_enabled()
+        if requires_conversion:
+            expected_dtype = result.dtype
+            x = x.to(next(iter(self.lora_AB)).weight.dtype)
+
+        output = self.lora_AB(self.lora_dropout(x))
+        if requires_conversion:
+            output = output.to(expected_dtype)
+        output = output * self.scaling
+
+        result += output
+
+        return result

--- a/tests/test_block_expansion.py
+++ b/tests/test_block_expansion.py
@@ -1,0 +1,44 @@
+import unittest, tempfile
+import torch
+import torch.nn as nn
+import safetensors
+from safetensors.torch import save_file
+from pathlib import Path
+from transformers.utils import hub, SAFE_WEIGHTS_NAME, SAFE_WEIGHTS_INDEX_NAME
+from glob import glob 
+
+# python -m unittest tests.test_quantize.TestQuantizer.test_quantizer
+class TestBlockExpansion(unittest.TestCase):
+
+    def setUp(self) -> None:
+        # set seed        
+        self.llama_pro_path = Path("/mnt/vol_b/models/meta-llama/Llama-2-7b-hf_blk_exp-32-35")
+        self.filenames = glob(str(self.llama_pro_path/"*.safetensors"))
+        num_original_layers, num_expanded_layers = self.llama_pro_path.name.split("blk_exp-")[1].split("-")
+        self.num_original_layers, self.num_expanded_layers = int(num_original_layers), int(num_expanded_layers)
+        self.split = int(self.num_original_layers / (self.num_expanded_layers - self.num_original_layers))
+
+        
+    def tearDown(self) -> None:
+        return super().tearDown()
+    
+    def test_expanded_weights(self):   
+        
+        total_new_layers = self.num_expanded_layers - self.num_original_layers
+        new_layer_ids = [self.split + (self.split + 1)*n for n in range(total_new_layers)]
+        
+        verify_weights = {}
+        for filename in self.filenames:
+            weights = safetensors.torch.load_file(str(filename))
+            for k,v in iter(weights.items()):
+                if any(((f"layers.{i}" in k) or (f"layers.{i-1}" in k) for i in new_layer_ids)):
+                    verify_weights[k] = v
+                    
+        for k,v in verify_weights.items():
+            if any(((f"layers.{i}" in k) for i in new_layer_ids)):
+                if 'down_proj' in k or 'o_proj' in k:
+                    assert torch.equal(v, torch.zeros_like(v))
+                else:
+                    lid = int(k.split("layers.")[1].split(".")[0])
+                    assert torch.equal(verify_weights[k.replace(f"layers.{lid}", f"layers.{lid-1}")], v)
+                

--- a/tests/test_dora.py
+++ b/tests/test_dora.py
@@ -1,0 +1,72 @@
+import sys
+sys.path.append('../scripts/')
+import unittest, tempfile
+from hqq.core.quantize import HQQLinear, HQQBackend, BaseQuantizeConfig
+import torch
+import torch.nn as nn
+from dora import HQQDORA, BNBDORA
+
+import bitsandbytes
+import bitsandbytes as bnb
+from bitsandbytes.nn import Linear4bit
+
+
+# python -m unittest tests.test_quantize.TestQuantizer.test_quantizer
+# hqq pinned: 72b2b641aadc44a7ded6b243915f90df3b3be385 (to_empty not compatible with FSDP after this commit)
+class TestHQQDORA(unittest.TestCase):
+
+    def setUp(self) -> None:
+        # set seed
+        torch.manual_seed(42)
+        quant_config = BaseQuantizeConfig(nbits=4, group_size=64, quant_zero=True,
+                                  quant_scale=True, offload_meta=True, view_as_float=True)
+        self.base_layer = HQQLinear(nn.Linear(128,256,bias=False), quant_config, compute_dtype=torch.float32)
+        HQQLinear.set_backend(HQQBackend.ATEN_BACKPROP)
+        return super().setUp()
+    
+    def tearDown(self) -> None:
+        return super().tearDown()
+    
+    def test_hqq_dora(self):   
+        """
+        Test:  m * (W + AB / ||W + AB||) @ X == m * ((W @ X + AB @ X) / ||W + AB||)
+        """
+        frozen_weight = self.base_layer.dequantize_aten().clone().cuda()
+        self.base_layer.dora_scale = frozen_weight.norm(p=2,dim=1)
+        hqq_dora = HQQDORA(self.base_layer, 16)
+        weight = (frozen_weight + hqq_dora.dora_layer.lora_B.weight @ hqq_dora.dora_layer.lora_A.weight)
+        norm_adapted = weight / weight.norm(p=2, dim=1).view(-1,1)
+        calc_weights = norm_adapted * hqq_dora.magnitude_layer.magnitude.view(-1,1)
+        x = torch.randn(1, 16,128).cuda().to(torch.float32)
+        closeness = torch.isclose(x @ calc_weights.t(), hqq_dora(x)).float().mean().item()
+        self.assertTrue(closeness > 0.99)
+        
+class TestBNBDORA(unittest.TestCase):
+
+    def setUp(self) -> None:
+        # set seed
+        torch.manual_seed(42)
+        self.base_layer = Linear4bit(128, 32, bias=False, quant_type="nf4", 
+                                     compute_dtype=torch.float32, quant_storage=torch.float32)
+        return super().setUp()
+    
+    def tearDown(self) -> None:
+        return super().tearDown()
+    
+    def test_bnb_dora(self):   
+        """
+        Test:  m * (W + AB / ||W + AB||) @ X == m * ((W @ X + AB @ X) / ||W + AB||)
+        """
+        # quantize and dequantize to avoid numerical mismatch during test.
+        self.base_layer.cuda()
+        frozen_weight = bnb.functional.dequantize_4bit(self.base_layer.weight.data, 
+                                                       self.base_layer.weight.quant_state).clone()
+        self.base_layer.dora_scale = frozen_weight.norm(p=2,dim=1)
+        bnb_dora = BNBDORA(self.base_layer, 16).cuda()
+        
+        weight = (frozen_weight + bnb_dora.dora_layer.lora_B.weight @ bnb_dora.dora_layer.lora_A.weight)
+        norm_adapted = weight / weight.norm(p=2, dim=1).view(-1,1)
+        calc_weights = norm_adapted * bnb_dora.magnitude_layer.magnitude.view(-1,1)
+        x = torch.randn(1, 16,128).cuda().to(torch.float32)
+        closeness = torch.isclose(x @ calc_weights.t(), bnb_dora(x)).float().mean().item() 
+        self.assertTrue(closeness > 0.99)

--- a/train.py
+++ b/train.py
@@ -346,7 +346,7 @@ def get_dataloader(tokenizer:PreTrainedTokenizerFast, args:Dict):
     elif args["dataset"] == "orca_math":
         dataset = load_dataset("microsoft/orca-math-word-problems-200k")['train'].shuffle(seed=42)
         # train with 10k for starters. Then 100k.
-        dataset = dataset.select(range(0,100000))
+        dataset = dataset.select(range(0,args['dataset_samples']))
         
     # truncate dataset so it's evenly divisible by grad_accumulation_steps
     dataset = dataset.select(range(0, len(dataset)-len(dataset)%(args["batch_size"]*args["gradient_accumulation_steps"])))
@@ -455,7 +455,7 @@ def get_wrapping_policy(custom_policy:bool=False, vanilla_policy:bool=False):
             )
     def self_attn_policy_fn(module):
         # Check module name is self_attn.
-        return isinstance(module, tuple(*LLAMA_ATTENTION_CLASSES.values(), *MISTRAL_ATTENTION_CLASSES.values()))
+        return isinstance(module, tuple((*LLAMA_ATTENTION_CLASSES.values(), *MISTRAL_ATTENTION_CLASSES.values())))
 
     def mlp_policy_fn(module):
         # Check module name is self_attn.


### PR DESCRIPTION
- BnB and HQQ 4-bit Llama-Pro FSDP training changes.
Can be tested with the following:

```bash
# create llama pro
python scripts/block_expansion.py \
--model_name meta-llama/Llama-2-7b-hf \
--output_dir /mnt/vol_b/models \
--expansion_rate 0.1

# train
python train.py \
--model_name meta-llama/Llama-2-7b-hf \
--dataset orca_math \
--dataset_samples 1000 \
--batch_size 8 \
--context_length 1024 \
--gradient_accumulation_steps 2 \
--train_type bnb_llama_pro \
--llama_pro_path /mnt/vol_b/models/meta-llama/Llama-2-7b-hf_blk_exp-32-35/ \
--sharding_strategy full_shard \
--use_gradient_checkpointing true \
--reentrant_checkpointing true \
--use_cpu_offload false \
--use_activation_cpu_offload false \
--log_to wandb \
--verbose true \
--project_name "fsdp-dora-tests" \
--save_model true \
--output_dir /mnt/vol_b/models/llama-7b-orca-math-1k-bnb-llama-pro
```

Results: https://wandb.ai/answerdotai/fsdp-dora-tests