### PR TITLE
fix multiprocess issue (RuntimeError An attempt has been made to start a new process before the current process has finished its bootstrapping phase)

### DIFF
--- a/train.py
+++ b/train.py
@@ -30,6 +30,8 @@ from typing import List, Dict
 from pathlib import Path
 from glob import glob
 
+from datasets import load_dataset
+
 # Argument parsing
 from fastcore.script import call_parse, bool_arg, Param
 
@@ -1033,6 +1035,8 @@ def main(
     group: str = None, # For wandb logging
     entity: str = None, # For wandb logging
 ):
+    if __name__ != '__main__':
+        return
 
     # Set world size
     if world_size == -1:

--- a/train.py
+++ b/train.py
@@ -30,8 +30,6 @@ from typing import List, Dict
 from pathlib import Path
 from glob import glob
 
-from datasets import load_dataset
-
 # Argument parsing
 from fastcore.script import call_parse, bool_arg, Param
 


### PR DESCRIPTION
Fix `RuntimeError` in https://github.com/AnswerDotAI/fsdp_qlora/issues/28 once and for all by protecting main code with `if __name__ != '__main__': return`

**Background:**
* The original issue occurred when the `awq` package was imported in `train.py` outside of a function. This was due to `peft` importing `awq` if installed, causing problems for users who had autoawq installed (me). The previous PR [#30](https://github.com/AnswerDotAI/fsdp_qlora/pull/30) solved by moving the peft imports inside the functions where the modules are needed.
* Yesterday @iseesaw reported that he ran into this error too https://github.com/AnswerDotAI/fsdp_qlora/pull/30#issuecomment-2074177115. Did some digging and found that the `multiprocess` package is causing the problem. It appears that importing multiprocess changes the way child processes are created, similar to the behavior on Windows (see [PyTorch documentation](https://pytorch.org/docs/stable/notes/windows.html#usage-multiprocessing)).
* Although the current `train.py` does not import multiprocess directly, the HuggingFace `datasets` package does. If a user modifies the code to import datasets, for example with `from datasets import load_dataset`, the error occurs.
* To fix this, this PR  protects the main code in `train.py` with `if __name__ != '__main__': return`, similar to how it was recommended in the error message.

**Error**:
```
RuntimeError: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```

This change should prevent the RuntimeError from occurring, regardless of whether the user imports packages that affect process creation.

